### PR TITLE
loosen invalid url check to accept any protocol

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -150,7 +150,7 @@ export class WorkerConnection {
 			// running in a window, was passed a workerPath
 			// create the SharedWorker and help other bare-mux clients get the workerPath
 
-			if (!workerPath.startsWith("/") && !workerPath.includes("://")) throw new Error("Invalid URL. Must be absolute or start at the root.");
+			if (!workerPath.startsWith("/") && !workerPath.includes(":")) throw new Error("Invalid URL. Must be absolute or start at the root.");
 			this.port = createPort(workerPath, inInit);
 			console.debug("bare-mux: setting localStorage bare-mux-path to", workerPath);
 			nativeLocalStorage["bare-mux-path"] = workerPath;


### PR DESCRIPTION
i've verified that even with `const baremuxWorkerURL="data:text/javascript;base64,Ly8gQHRzLW5vY2hlY2sKIWZ1bmN0aW9uKCl7InVzZSBzdHJpY3QiO2NvbnN0IGU9TWVzc2FnZVBvcnQucHJvdG90eXBlLnBvc3RNZXNzYWdlO2xldCB0PW51bGw7ZnVuY3Rpb24gYShlLHQsYSl7Y29uc29sZS5lcnJvcihgZXJyb3Igd2hpbGUgcHJvY2Vzc2luZyAnJHthfSc6IGAsdCksZS5wb3N0TWVzc2FnZSh7dHlwZToiZXJyb3IiLGVycm9yOnR9KX1hc3luYyBmdW5jdGlvbiBuKGEsbixzKXtjb25zdCBvPWF3YWl0IHMucmVxdWVzdChuZXcgVVJMKGEuZmV0Y2gucmVtb3RlKSxhLmZldGNoLm1ldGhvZCxhLmZldGNoLmJvZHksYS5mZXRjaC5oZWFkZXJzLG51bGwpO2lmKCFmdW5jdGlvbigpe2lmKG51bGw9PT10KXtjb25zdCBhPW5ldyBNZXNzYWdlQ2hhbm5lbCxuPW5ldyBSZWFkYWJsZVN0cmVhbTtsZXQgczt0cnl7ZS5jYWxsKGEucG9ydDEsbixbbl0pLHM9ITB9Y2F0Y2goZSl7cz0hMX1yZXR1cm4gdD1zLHN9cmV0dXJuIHR9KCkmJm8uYm9keSBpbnN0YW5jZW9mIFJlYWRhYmxlU3RyZWFtKXtjb25zdCBlPW5ldyBSZXNwb25zZShvLmJvZHkpO28uYm9keT1hd2FpdCBlLmFycmF5QnVmZmVyKCl9by5ib2R5IGluc3RhbmNlb2YgUmVhZGFibGVTdHJlYW18fG8uYm9keSBpbnN0YW5jZW9mIEFycmF5QnVmZmVyP2UuY2FsbChuLHt0eXBlOiJmZXRjaCIsZmV0Y2g6b30s...` the worker will still init properly, so redefine the "is a protocol" check from "includes `://`" to "includes `:`"

this will all be wiped out once @r58Playz ports their "better system" but it's worth fixing in the meantime