### PR TITLE
set `cause` for All clients returned an invalid MessagePort.

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -57,7 +57,7 @@ async function searchForPort(): Promise<MessagePort> {
 	} catch (err) {
 		if (err instanceof AggregateError) {
 			console.error("bare-mux: failed to get a bare-mux SharedWorker MessagePort as all clients returned an invalid MessagePort.");
-			throw new Error("All clients returned an invalid MessagePort.");
+			throw new Error("All clients returned an invalid MessagePort.", { cause: err });
 		}
 		console.warn("bare-mux: failed to get a bare-mux SharedWorker MessagePort within 1s, retrying");
 		return await searchForPort();


### PR DESCRIPTION
i'll make a pr to scramjet to display the `cause` of errors soon so this'll help with debugging